### PR TITLE
Update react-native-router-flx to 4.0.0-beta.27 to fix issue with typ…

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react": "^16.0.0-beta.5",
     "react-dom": "^16.2.0",
     "react-native": "^0.49.5",
-    "react-native-router-flux": "^4.0.0-beta.24",
+    "react-native-router-flux": "4.0.0-beta.27",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
     "reactstrap": "^5.0.0-alpha.4",


### PR DESCRIPTION
Was having an issue where the console was reporting an error looking like `undefined is not an object (evaluating resetAction.actions.map)`. Found the issue was with react-native-router-flux, described here: https://github.com/aksonov/react-native-router-flux/issues/2799. Updating to version 4.0.0-beta.27 fixes it. This resolves https://github.com/mcnamee/react-native-starter-kit/issues/136.